### PR TITLE
TG-26: Hot fix hiltCompiler

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
+    id 'dagger.hilt.android.plugin'
 }
 
 android {
@@ -47,7 +49,7 @@ dependencies {
     androidTestImplementation TestLibraries.espresso
 
     implementation Libraries.daggerHilt
-    implementation Libraries.hiltCompiler
+    kapt Libraries.hiltCompiler
 
     implementation AndroidLibraries.hawk
 

--- a/feature/account/build.gradle.kts
+++ b/feature/account/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id ("com.google.dagger.hilt.android")
+    id ("kotlin-kapt")
 }
 
 android {
@@ -52,7 +53,7 @@ dependencies {
     implementation(AndroidLibraries.material)
 
     implementation(Libraries.daggerHilt)
-    implementation(Libraries.hiltCompiler)
+    kapt(Libraries.hiltCompiler)
     implementation(Libraries.hiltNavigationCompose)
 
     implementation(AndroidLibraries.retrofit)

--- a/feature/authentication/build.gradle.kts
+++ b/feature/authentication/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id ("com.google.dagger.hilt.android")
+    id ("kotlin-kapt")
 }
 
 android {
@@ -52,7 +53,7 @@ dependencies {
     implementation(AndroidLibraries.material)
 
     implementation(Libraries.daggerHilt)
-    implementation(Libraries.hiltCompiler)
+    kapt(Libraries.hiltCompiler)
     implementation(Libraries.hiltNavigationCompose)
 
     implementation(AndroidLibraries.retrofit)

--- a/feature/more/build.gradle.kts
+++ b/feature/more/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id ("com.google.dagger.hilt.android")
+    id ("kotlin-kapt")
 }
 
 android {
@@ -54,7 +55,7 @@ dependencies {
     androidTestImplementation(TestLibraries.espresso)
 
     implementation(Libraries.daggerHilt)
-    implementation(Libraries.hiltCompiler)
+    kapt(Libraries.hiltCompiler)
     implementation(Libraries.hiltNavigationCompose)
 
 }

--- a/feature/stats/build.gradle.kts
+++ b/feature/stats/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id ("com.google.dagger.hilt.android")
+    id ("kotlin-kapt")
 }
 
 android {
@@ -53,7 +54,7 @@ dependencies {
     androidTestImplementation(TestLibraries.espresso)
 
     implementation(Libraries.daggerHilt)
-    implementation(Libraries.hiltCompiler)
+    kapt(Libraries.hiltCompiler)
     implementation(Libraries.hiltNavigationCompose)
 
     implementation(AndroidLibraries.retrofit)

--- a/feature/trans/build.gradle.kts
+++ b/feature/trans/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id ("com.google.dagger.hilt.android")
+    id ("kotlin-kapt")
 }
 
 android {
@@ -54,7 +55,7 @@ dependencies {
     androidTestImplementation(TestLibraries.espresso)
 
     implementation(Libraries.daggerHilt)
-    implementation(Libraries.hiltCompiler)
+    kapt(Libraries.hiltCompiler)
     implementation(Libraries.hiltNavigationCompose)
 
     implementation(AndroidLibraries.retrofit)


### PR DESCRIPTION
## Description & Motivation

Before I implement hiltCompiler by keyword **implementation** which lead to crash when use DI. So now I fix it by change to **kapt**

## Ticket number and links

## Screenshots

## Checklist

- [x] I have reviewed my own code
- [x] I have verified that my commits are properly labelled
- [x] I have updated any related documentation
- [x] I have added appropriate tests for my new changes
- [x] I have updated any existing tests related to my changes