### PR TITLE
TG-35: Fix build release crash

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,7 +23,7 @@ android {
         }
 
         release {
-            buildConfigField("String", "BASE_URL", "\"Your prod api endpoint\"")
+            buildConfigField("String", "BASE_URL", "\"http:192.168.2.1:3000/api/v1/\"")
 
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
## Description & Motivation

App crash when build release because of I haven't set base url for release build variant in build gradle. So I add base_url to fix it

## Ticket number and links


## Screenshots

## Checklist

- [x] I have reviewed my own code
- [x] I have verified that my commits are properly labelled
- [x] I have updated any related documentation
- [x] I have added appropriate tests for my new changes
- [x] I have updated any existing tests related to my changes